### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following encryption methods are supported:
 - `false` &mdash; Disable encryption 
 - `ssl` &mdash; Use SSL
 - `tls` &mdash; Use TLS
+- `starttls` &mdash; Use STARTTLS
 
 Detailed [config/imap.php](src/config/imap.php) configuration:
  - `default` &mdash; used default account


### PR DESCRIPTION
Adicionando encryption STARTTLS, que "/tls" da função imap_open.
 "/tls" segundo [PHP.NET](https://www.php.net/manual/pt_BR/function.imap-open.php): “force use of start-TLS to encrypt the session, and reject connection to servers that do not support it”